### PR TITLE
Change link that was not translated

### DIFF
--- a/docs_pt-br/tutorial/atualizando-nossa-aplicacao/index.md
+++ b/docs_pt-br/tutorial/atualizando-nossa-aplicacao/index.md
@@ -9,7 +9,7 @@ Simples, não? Vamos fazer essa mudança.
 
 ## Atualizando nosso código fonte
 
-1. No arquivo `~/app/src/static/js/app.js` atualize a linha 56 para que o novo "texto vazio" seja utilizado. ([Dicas de edição de arquivos no PWD aqui](/pwd-tips#editing-files))
+1. No arquivo `~/app/src/static/js/app.js` atualize a linha 56 para que o novo "texto vazio" seja utilizado. ([Dicas de edição de arquivos no PWD aqui](/dicas-pwd/#editando-arquivos))
 
     ```diff
     - <p className="text-center">No items yet! Add one above!</p>


### PR DESCRIPTION
Thi fixes the link for PWD tips about editing files when using `pt-br` labeled image