### PR TITLE
A possibly better idea than docker rm

### DIFF
--- a/docs_en/tutorial/using-docker-compose/index.md
+++ b/docs_en/tutorial/using-docker-compose/index.md
@@ -247,7 +247,7 @@ volumes:
 
 Now that we have our `docker-compose.yml` file, we can start it up!
 
-1. Make sure no other copies of the app/db are running first (`docker ps` and `docker rm -f <ids>`).
+1. Make sure no other copies of the app/db are running first (`docker-compose down --volumes`).
 
 1. Start up the application stack using the `docker-compose up` command. We'll add the `-d` flag to run everything in the
    background.


### PR DESCRIPTION
Since one could have run `docker-compose up` in the previous, the volume for the database could already exists, but without the `todos` database. Running `docker-compose down --volumes` would fix this (as actually advised in a warning later on.
Ref: https://stackoverflow.com/q/61925112/2123530