### PR TITLE
Update for Apple Silicon Mac's Docker.

### DIFF
--- a/docs_en/tutorial/our-application/index.md
+++ b/docs_en/tutorial/our-application/index.md
@@ -51,7 +51,7 @@ see a few flaws in the Dockerfile below. But, don't worry! We'll go over them.
 1. Create a file named Dockerfile with the following contents.
 
     ```dockerfile
-    FROM node:10-alpine
+    FROM node:14
     WORKDIR /app
     COPY . .
     RUN yarn install --production


### PR DESCRIPTION
Using alpine failes for some reason on new Silicon Macs. Through running some modifications it's working fine.