### PR TITLE
"main" in package.json is a broken link

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "101-app",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "src/index.js",
   "license": "MIT",
   "scripts": {
     "prettify": "prettier -l --write \"**/*.js\"",


### PR DESCRIPTION
The tutorial doesn't actually use this field, but I think it's still wrong