### PR TITLE
Add explanation for the bind mount operation

### DIFF
--- a/docs_en/tutorial/using-bind-mounts/index.md
+++ b/docs_en/tutorial/using-bind-mounts/index.md
@@ -47,6 +47,7 @@ So, let's do it!
 
     - `-dp 3000:3000` - same as before. Run in detached (background) mode and create a port mapping
     - `-w /app` - sets the "working directory" or the current directory that the command will run from
+    - `-v "$(pwd):/app"` - bind mount the current directory from the host in the container into the `/app` directory
     - `node:10-alpine` - the image to use. Note that this is the base image for our app from the Dockerfile
     - `sh -c "yarn install && yarn run dev"` - the command. We're starting a shell using `sh` (alpine doesn't have `bash`) and
       running `yarn install` to install _all_ dependencies and then running `yarn run dev`. If we look in the `package.json`,


### PR DESCRIPTION
The bind mount operation is explained in the Docker Desktop version of this tutorial but not for this PWD version.